### PR TITLE
Error when trying to convert a file with compatible container but incompatible A/V format

### DIFF
--- a/chromecastize.sh
+++ b/chromecastize.sh
@@ -128,12 +128,13 @@ process_file() {
 	# test general format
         INPUT_GFORMAT=`mediainfo --Inform="General;%Format%\n" "$FILENAME" | head -n1`
         if is_supported_gformat "$INPUT_GFORMAT" && [ "$OVERRIDE_GFORMAT" = "" ] || [ "$OVERRIDE_GFORMAT" = "$EXTENSION" ]; then
-                OUTPUT_GFORMAT="ok"
+                OUTPUT_GFORMAT="$INPUT_GFORMAT"
+                echo "- general: $INPUT_GFORMAT -> ok"
         else
                 # if override format is specified, use it; otherwise fall back to default format
                 OUTPUT_GFORMAT="${OVERRIDE_GFORMAT:-$DEFAULT_GFORMAT}"
+                echo "- general: $INPUT_GFORMAT -> $OUTPUT_GFORMAT"
         fi
-        echo "- general: $INPUT_GFORMAT -> $OUTPUT_GFORMAT"
 
         # test video codec
         INPUT_VCODEC=`mediainfo --Inform="Video;%Format%\n" "$FILENAME" | head -n1`
@@ -153,7 +154,7 @@ process_file() {
         fi
         echo "- audio: $INPUT_ACODEC -> $OUTPUT_ACODEC"
 
-        if [ "$OUTPUT_VCODEC" = "copy" ] && [ "$OUTPUT_ACODEC" = "copy" ] && [ "$OUTPUT_GFORMAT" = "ok" ]; then
+        if [ "$OUTPUT_VCODEC" = "copy" ] && [ "$OUTPUT_ACODEC" = "copy" ] && [ is_supported_gformat "$OUTPUT_GFORMAT" ]; then
                 echo "- file should be playable by Chromecast!"
 		mark_as_good "$FILENAME"
 	else


### PR DESCRIPTION
I have a media file that has a compatible container format (MPEG-4) but an incompatible audio format (AC-3). When I try to convert this file it fails with the error "Unable to find a suitable output format".

```
Processing: myfile.mp4
- general: MPEG-4 -> ok
- video: AVC -> copy
- audio: AC-3 -> libvorbis
- video length: 01:44:59.250
[NULL @ 0x55fc40905980] Unable to find a suitable output format for 'myfile.mp4.ok'
myfile.mp4.ok: Invalid argument
- failed to convert 'myfile.mp4' (or conversion has been interrupted)
- deleting partially converted file...
```

In the logic of the script if the container format is compatible, this is changed to "ok", but FFMPEG does not recognize "ok" as a container format.