### PR TITLE
Specify AVC profile, level, and pixel format

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install requirements by running e.g. `apt-get install ffmpeg mediainfo` (Debian)
 Usage
 -----
 ```
-./chromecastize.sh [--mp4 | --mkv | --config=/path/to/config] <videofile1> [videofile2 ...]
+./chromecastize.sh [--mp4 | --mkv | --force-vencode | --force-aencode | --config=/path/to/config] <videofile1> [videofile2 ...]
 ```
 
 ### Examples:
@@ -26,6 +26,8 @@ Usage
 ### Options:
 - `--mp4` forces conversion to MPEG-4 container
 - `--mkv` forces conversion to Matroska container
+- `--force-vencode` forces re-encoding of the video, if the codec is supported but the profile level is too high
+- `--force-aencode` forces re-encoding of the audio
 - `--config=/path/to/config` specify where to store configuration. When omitted the default folder `~/.chromecastize` is used.
 
 Authors


### PR DESCRIPTION
Add options to force encoding if compatability check is faulty

Checking the video format is insufficient to ensure video codec compatibility to chromecast. A file encoded with profile `High 4:4:4 Predictive@L5` doesn't play on my 2nd gen chromecast for example.

I've added a log statement to display the input video's profile, if available. Profiles like `High @L4.1` `High @L3` are ok. But I don't know a good way to parse this field in bash, so instead I've added a command line option to force the re-encoding.

In order to get ffmpeg to actually transcode my 4:4:4 video to 4:2:0, I had to add the `-pix_fmt yuv420p` encoding option. 