### PR TITLE
adds ONSUCCESS option: keep to keep the original file

### DIFF
--- a/chromecastize.sh
+++ b/chromecastize.sh
@@ -110,6 +110,9 @@ on_success() {
 	if [ "$ONSUCCESS" = "delete" ]; then
 		echo "- deleting original file"
 		rm -f "$FILENAME"
+	elif [ "$ONSUCCESS" = "keep" ]; then
+		DESTINATION_FILENAME="$FILENAME-chromecast.$OUTPUT_GFORMAT"
+		echo "- keeping original file; creating $DESTINATION_FILENAME"
 	else
 		echo "- renaming original file as '$FILENAME.bak'"
 		mv "$FILENAME" "$FILENAME.bak"	

--- a/config.sh
+++ b/config.sh
@@ -112,6 +112,7 @@
 # Options are:
 #  - bak (default) - will move the original file to a .bak extension
 #  - delete - will delete the original file and just keep the converted file
+#  - keep - will keep the original file and create a new converted file with the '-chromecast' suffix
 #ONSUCCESS=bak
 
 # Suggested options for Chromecast Gen. 1 and Gen 2.


### PR DESCRIPTION
Sometimes is important to keep the original file.
This new ONSUCCESS option ("keep") keeps the original file and creates a new one with the '-chromecast' tag between the name and the extension.

This way a torrent client can keep seeding the original file.