### PR TITLE
h264 profile and level check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data
+processed_files

--- a/chromecastize.sh
+++ b/chromecastize.sh
@@ -12,6 +12,8 @@ UNSUPPORTED_GFORMATS=('BDAV' 'AVI' 'Flash Video' 'DivX')
 SUPPORTED_VCODECS=('AVC' 'VP8')
 UNSUPPORTED_VCODECS=('MPEG-4 Visual' 'xvid' 'MPEG Video' 'HEVC')
 
+SUPPORTED_VFPROFILE=('Main@L4' 'High@L3.1' 'High@L4' 'High@L4.1')
+
 SUPPORTED_ACODECS=('AAC' 'MPEG Audio' 'Vorbis' 'Ogg' 'Opus')
 UNSUPPORTED_ACODECS=('AC-3' 'DTS' 'E-AC-3' 'PCM' 'TrueHD' 'FLAC')
 
@@ -75,6 +77,14 @@ is_supported_vcodec() {
 	else
 		unknown_codec "$1"
 		exit 1
+	fi
+}
+
+is_supported_vfprofile() {
+	if in_array "$1" "${SUPPORTED_VFPROFILE[@]}"; then
+		return 0
+	else
+		return 1
 	fi
 }
 
@@ -168,7 +178,7 @@ process_file() {
 
 	INPUT_VCODEC=`$MEDIAINFO --Inform="Video;%Format%\n" "$FILENAME" 2> /dev/null | head -n1`
 	ENCODER_OPTIONS=""
-	if is_supported_vcodec "$INPUT_VCODEC" && [ -z "$FORCE_VENCODE" ]; then
+	if is_supported_vcodec "$INPUT_VCODEC" && is_supported_vfprofile "$INPUT_VCODEC_PROFILE" [ -z "$FORCE_VENCODE" ]; then
 		OUTPUT_VCODEC="copy"
 	else
 		OUTPUT_VCODEC="$DEFAULT_VCODEC"

--- a/config.sh
+++ b/config.sh
@@ -119,6 +119,7 @@
 #SUPPORTED_GFORMATS=('MPEG-4' 'Matroska' 'WebM')
 #DEFAULT_GFORMAT=mkv
 #SUPPORTED_VCODECS=('AVC' 'VP8')
+#SUPPORTED_VFPROFILE=('High@L3.1' 'High@L4' 'High@L4.1')
 #DEFAULT_VCODEC=h264
 #DEFAULT_VCODEC_OPTS="-preset fast -profile:v high -level 4.1 -crf 17 -pix_fmt yuv420p"
 #SUPPORTED_ACODECS=('AAC' 'MPEG Audio' 'Vorbis' 'Ogg' 'Opus')
@@ -128,6 +129,7 @@
 #SUPPORTED_GFORMATS=('MPEG-4' 'Matroska' 'WebM')
 #DEFAULT_GFORMAT=mkv
 #SUPPORTED_VCODECS=('AVC' 'VP8')
+#SUPPORTED_VFPROFILE=('High@L3.1' 'High@L4' 'High@L4.1' 'High@L4.2')
 #DEFAULT_VCODEC=h264
 #DEFAULT_VCODEC_OPTS="-preset fast -profile:v high -level 4.2 -crf 17 -pix_fmt yuv420p"
 #SUPPORTED_ACODECS=('AAC' 'MPEG Audio' 'Vorbis' 'Ogg' 'Opus')
@@ -137,6 +139,7 @@
 #SUPPORTED_GFORMATS=('MPEG-4' 'Matroska' 'WebM')
 #DEFAULT_GFORMAT=mkv
 #SUPPORTED_VCODECS=('AVC' 'HEVC' 'VP8' 'VP9')
+#SUPPORTED_VFPROFILE=('High@L3.1' 'High@L4' 'High@L4.1' 'High@L4.2')
 #UNSUPPORTED_VCODECS=('MPEG-4 Visual' 'xvid' 'MPEG Video')
 #DEFAULT_VCODEC=libx265
 #DEFAULT_VCODEC_OPTS="-preset fast -level 5.2 -crf 17"


### PR DESCRIPTION
- script checks h264 profile and level
- config does not need `.sh` extension since there are only variables inside

I will keep this PR as draft until I test with more videos and add more supported and unsupported profiles and levels.
Feel free to comment if you do not agree with some of my changes. 